### PR TITLE
Kelvin2 - fix: Add Authorization Header to Axios Requests

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,7 @@ flask-cors = "*"
 python-dotenv = "*"
 cloudinary = "*"
 flask-wtf = "*"
+python-dateutil = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3ed90a2c82e8284a3ea5e3fcb7d39e7312585eae0d8e83629d0891cf737251a3"
+            "sha256": "5db211415dfb8e021c2ef3d6fea58cd83c4e0fe5f0ead156af9bca870b091b10"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -367,6 +367,15 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==2.8.0"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.8.2"
         },
         "python-dotenv": {
             "hashes": [

--- a/app/src/components/hrUI/PendingLeavesHr.js
+++ b/app/src/components/hrUI/PendingLeavesHr.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import './PendingLeavesHr.css';
+import { retrieve } from "../Encryption";
 
 const PendingLeaves = () => {
   const [leaves, setLeaves] = useState([]);
@@ -26,7 +27,11 @@ const PendingLeaves = () => {
 
   const handleApprove = async (leaveId) => {
     try {
-      const response = await axios.patch(`http://localhost:5555/leave/approval/${leaveId}`, { hr_approval: true });
+      const response = await axios.patch(`http://localhost:5555/leave/approval/${leaveId}`, { hr_approval: true }, {
+        headers: {
+          'Authorization': `Bearer ${retrieve().access_token}`
+        }
+      });
       console.log('Leave approved:', response.data);
       setSuccess('Leave approved'); 
     } catch (error) {
@@ -40,7 +45,11 @@ const PendingLeaves = () => {
 
   const handleDecline = async (leaveId) => {
     try {
-      const response = await axios.patch(`http://localhost:5555/leave/approval/${leaveId}`, { hr_approval: false });
+      const response = await axios.patch(`http://localhost:5555/leave/approval/${leaveId}`, { hr_approval: false }, {
+        headers: {
+          'Authorization': `Bearer ${retrieve().access_token}`
+        }
+      });
       console.log('Leave declined:', response.data);
       setSuccess('Leave declined');
     } catch (error) {

--- a/server/migrations/versions/530e0d3d7703_initial_migration.py
+++ b/server/migrations/versions/530e0d3d7703_initial_migration.py
@@ -1,8 +1,8 @@
 """initial migration
 
-Revision ID: 03746229f9b9
+Revision ID: 530e0d3d7703
 Revises: 
-Create Date: 2024-02-24 09:41:28.975698
+Create Date: 2024-02-25 19:39:32.357304
 
 """
 from alembic import op
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = '03746229f9b9'
+revision = '530e0d3d7703'
 down_revision = None
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
**Changes made**
- fix: Add Authorization Header to Axios Requests - This commit includes the addition of an Authorization header to the Axios PATCH requests in the handleApprove and handleDecline functions in the PendingLeaves component. This was done to resolve a 401 (UNAUTHORIZED) error that was occurring due to the server expecting an authorization token in the request headers, which was not being provided. The access token is now retrieved from local storage using the retrieve function and included in the headers of the requests.